### PR TITLE
Set up run target in RAM

### DIFF
--- a/flash_loader_link.cmd
+++ b/flash_loader_link.cmd
@@ -60,9 +60,10 @@ MEMORY
     FLASH   (RX)    : origin=0x00000040 length=0x0000FFC0
 
 	// SRAM on 0914 is 128 kBytes or 0x20000
-    STACKS  (RW)    : origin=0x08000000 length=0x00001500
-	RAM (RW)        : origin=0x08001500 length=0x0001EAE0
-	RAMVECTORS(RWX) : origin=0x0801FFE0 length=0x00000020
+	RUNTARGET (RW)  : origin=0x08000000 length=0x00000010
+    STACKS  (RW)    : origin=0x08000010 length=0x000014F0
+    RAM (RW)        : origin=0x08001500 length=0x0001EAE0
+    RAMVECTORS(RWX) : origin=0x0801FFE0 length=0x00000020
 
 /* USER CODE BEGIN (2) */
 /* USER CODE END */
@@ -90,6 +91,7 @@ SECTIONS
     .cinit       : {} > FLASH
     .binit	     : {} > FLASH
     .ovly		 : {} > FLASH
+	.runTarget   : {} > RUNTARGET, type = NOINIT
     .bss         : {} > RAM
     .data        : {} > RAM
     .sysmem      : {} > RAM

--- a/halcogen/source/sys_startup.c
+++ b/halcogen/source/sys_startup.c
@@ -219,6 +219,13 @@ void _c_int00(void)
         Add user code to handle software reset. */
 		
 /* USER CODE BEGIN (22) */
+    	systemInit();
+    	copy_in(&ram_undef);
+    	_coreEnableIrqVicOffset_();
+    	vimInit();
+    	esmInit();
+    	__TI_auto_init();
+    	main();
 /* USER CODE END */
 	}
     else

--- a/loader/bl_include/bl_check.h
+++ b/loader/bl_include/bl_check.h
@@ -28,13 +28,11 @@
 
 //*****************************************************************************
 //
-// Prototype for the forced update check function.
+// Prototypes for the check functions.
 //
 //*****************************************************************************
-uint32_t CheckForceUpdate(void);
-#ifdef ENABLE_UPDATE_CHECK
-uint32_t CheckGPIOForceUpdate(void);
-extern uint32_t g_ulForced;
-#endif
+bool isApplicationValid(void);
+bool isGPIOactive(void);
+bool runApplication(void);
 
 #endif // __BL_CHECK_H__

--- a/loader/bl_include/bl_run_target.h
+++ b/loader/bl_include/bl_run_target.h
@@ -1,0 +1,31 @@
+//-------------------------------------------------------------------------------
+// bl_run_target.h
+//
+// Heimir Thor Sverrisson, w1ant, heimir.sverrisson@gmail.com
+//
+// Definitions to set and read the run target value stored in SRAM
+//
+//-------------------------------------------------------------------------------
+
+#ifndef __BL_RUN_TARGET_H__
+#define __BL_RUN_TARGET_H__
+
+#include "sys_common.h"
+
+extern int run_target;  // Defined in run_target_address.asm
+
+enum target_value {
+	FLASH_LOADER,
+	APPLICATION,
+	UNKNOWN
+};
+
+const char * get_target_name(enum target_value target);
+
+void set_target(enum target_value target);
+
+enum target_value get_target();
+
+void softReset();
+
+#endif /* __BL_RUN_TARGET_H__ */

--- a/loader/bl_include/sci_common.h
+++ b/loader/bl_include/sci_common.h
@@ -37,7 +37,7 @@ uint32_t Str2Int(unsigned char *inputstr,int *intnum);
 uint32_t UART_getInteger(sciBASE_t *sci, int * num);
 char UART_getKey(sciBASE_t *sci);
 void UART_putChar(sciBASE_t *sci, char c);
-void UART_putString(sciBASE_t *sci, char *s);
+void UART_putString(sciBASE_t *sci, const char *s);
 //int UART_rxByte (sciBASE_t *sci, char *c, uint32_t timeout);
 uint32_t UART_txByte (sciBASE_t *sci, char c);
 int UART_getChar(sciBASE_t *sci, uint32_t timeout);

--- a/loader/bl_source/bl_check.c
+++ b/loader/bl_source/bl_check.c
@@ -27,6 +27,7 @@
 #include "bl_check.h"
 #include "sci.h"
 #include "het.h"
+#include "bl_run_target.h"
 
 //*****************************************************************************
 //
@@ -34,19 +35,9 @@
 //
 //*****************************************************************************
 
-//*****************************************************************************
-//
-// This global is used to remember if a forced update occurred.
-//
-//*****************************************************************************
-
 extern unsigned int g_pulUpdateSuccess[8];
 extern unsigned int g_pulUpdateFail[8];
 extern unsigned int g_ulUpdateStatusAddr;
-
-#ifdef ENABLE_UPDATE_CHECK
-uint32_t g_ulForced;
-#endif
 
 #if (FORCED_UPDATE_PORT == GPIO_PORTA_BASE)
 #define gioPORT gioPORTA
@@ -54,19 +45,7 @@ uint32_t g_ulForced;
 #define gioPORT gioPORTB
 #endif
 
-//*****************************************************************************
-//
-// Checks a GPIO for a forced update.
-//
-// This function checks the state of a GPIO to determine if a update is being
-// requested.
-//
-// \return Returns a non-zero value if an update is being requested and zero
-// otherwise.
-//
-//*****************************************************************************
-#ifdef ENABLE_UPDATE_CHECK
-uint32_t CheckGPIOForceUpdate(void) {
+bool isGPIOactive(void) {
 #ifndef N2HET_INPUT_PIN
 	/** bring GIO module out of reset */
 	gioREG->GCR0 = 1;
@@ -79,60 +58,47 @@ uint32_t CheckGPIOForceUpdate(void) {
 	// Check the pin to see if an update is being requested.
 
 	if (!((gioPORT->DIN & (0x1 << FORCED_UPDATE_PIN)) == 0)) {
-		// Remember that this was a forced update.
-		g_ulForced = 1;
 		return (1);
 	}
 #else	// We are using N2HET pin rather than GPIO
 	hetREG1->DIR &= ~(1 << N2HET_INPUT_PIN);
 	if (!((hetREG1->DIN & (0x1 << N2HET_INPUT_PIN)) == 0)) {
-		// Remember that this was a forced update.
-		g_ulForced = 1;
-		return (1);
+		return (true);
 	}
 #endif
-	// No update is being requested so return 0.
-	return (0);
+	return (false);
 }
-#endif
 
-//*****************************************************************************
-//
-// Checks if an update is needed or is being requested.
-//
-// This function detects if an update is being requested or if there is no
-// valid code presently located on the microcontroller.  This is used to tell
-// whether or not to enter update mode.
-//
-// \return Returns a non-zero value if an update is needed or is being
-// requested and zero otherwise.
-//
-//*****************************************************************************
-uint32_t CheckForceUpdate(void) {
+// Return true if we should run the application
+// false if we should stay in the flash loader
+bool runApplication(void){
+	enum target_value target;
+	target = get_target();
+	if(isGPIOactive()){
+		switch(target){
+			case FLASH_LOADER: return false;
+			case APPLICATION:  return true;
+			case UNKNOWN:      return false;
+			default:		   return false;
+		}
+	} else {
+		switch(target){
+			case FLASH_LOADER: return false;
+			case APPLICATION:  return true;
+			case UNKNOWN:      return true;
+			default:           return true;
+		}
+	}
+}
+
+bool isApplicationValid(void) {
 	uint32_t *pulApp;
 
-#ifdef ENABLE_UPDATE_CHECK
-	g_ulForced = 0;
-#endif
-
-	//
-	// See if the last word of 1st sector to see it is 0xFFFFFFFF. If it is 0xFFFFFFFF,
-	// there is no application code in the flash. The update is required
-	//
+	// Read in the status area of the application
 	pulApp = (uint32_t*) g_ulUpdateStatusAddr;
-#ifdef DEBUG_MSG
-	UART_putString(UART, "Application valid pattern: ");
-	UART_send32BitData(sciREG1, pulApp[0]);
-	UART_putString(UART, "\r\nApplication image size: ");
-	UART_send32BitData(sciREG1, pulApp[2]);
-	UART_putString(UART, "\r\nApplication image address: ");
-	UART_send32BitData(sciREG1, pulApp[1]);
-	UART_putString(UART, "\r\n");
-#endif
 
-	if ((pulApp[0] != g_pulUpdateSuccess[0])) { // Pattern is not 0x5A5A5A5A
-		return (1);    //1 means Need New UPDATE
+	if ((pulApp[0] == g_pulUpdateSuccess[0])) { // Pattern is 0x5A5A5A5A
+		return (true);    //1 means that pattern is there
 	}
-    return(0);
+    return(false);
 }
-

--- a/loader/bl_source/bl_main.c
+++ b/loader/bl_source/bl_main.c
@@ -2,34 +2,6 @@
 * Copyright (C) 2009-2018 Texas Instruments Incorporated - www.ti.com 
 * 
 * 
-*  Redistribution and use in source and binary forms, with or without 
-*  modification, are permitted provided that the following conditions 
-*  are met:
-*
-*    Redistributions of source code must retain the above copyright 
-*    notice, this list of conditions and the following disclaimer.
-*
-*    Redistributions in binary form must reproduce the above copyright
-*    notice, this list of conditions and the following disclaimer in the 
-*    documentation and/or other materials provided with the   
-*    distribution.
-*
-*    Neither the name of Texas Instruments Incorporated nor the names of
-*    its contributors may be used to endorse or promote products derived
-*    from this software without specific prior written permission.
-*
-*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
-*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
-*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-*  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
-*  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
-*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-*  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-*  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-*  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
 */
 
 #include "bl_config.h"
@@ -111,10 +83,8 @@ void loader_main(void) {
     hetREG1->INTENAC = 0xFFFFFFFF;
     hetREG1->FLG = 0xFFFFFFFF;
 #endif
-	// Bring GIO out of reset before the call to CheckForceUpdate() below
-	CheckGPIOForceUpdate();
 
-	if (!CheckGPIOForceUpdate() && !CheckForceUpdate()) {
+	if (isApplicationValid() && runApplication()) {
 		g_ulTransferAddress = (uint32_t) APP_START_ADDRESS;
 		((void (*)(void)) g_ulTransferAddress)();
 	}

--- a/loader/bl_source/bl_run_target.c
+++ b/loader/bl_source/bl_run_target.c
@@ -1,0 +1,54 @@
+//-------------------------------------------------------------------------------
+// bl_run_target.c
+//
+// Heimir Thor Sverrisson, w1ant, heimir.sverrisson@gmail.com
+//
+// Code to set and read the run target value stored in SRAM
+//
+//-------------------------------------------------------------------------------
+
+#include "bl_run_target.h"
+#include "system.h"
+
+// The patterns stored in RAM for each run target.
+// Actually Unknown is anything but FLASH_LOADER or APPLICATION
+
+#define FLASH_LOADER_PATTERN 0x55555555
+#define APPLICATION_PATTERN  0xAAAAAAAA
+#define UNKNOWN_PATTERN      0x00000000
+
+uint32_t target_pattern[] = {
+		FLASH_LOADER_PATTERN,
+		APPLICATION_PATTERN,
+		UNKNOWN_PATTERN
+};
+
+const char * get_target_name(enum target_value target){
+	switch(target){
+		case FLASH_LOADER: 	return "Flash loader";
+		case APPLICATION:	return "Application";
+		case UNKNOWN:		return "Unknown";
+	}
+	return "Unknown";
+}
+
+void set_target(enum target_value target){
+	run_target = target_pattern[target];
+}
+
+enum target_value get_target(){
+	switch(run_target){
+		case FLASH_LOADER_PATTERN:
+			return FLASH_LOADER;
+		case APPLICATION_PATTERN:
+			return APPLICATION;
+		default:
+			return UNKNOWN;
+	}
+}
+int main(void);
+
+void softReset(){
+	systemREG1->SYSECR |= 0x8000; // Set the 15th bit to perform software reset interrupt
+}
+

--- a/loader/bl_source/run_target_address.asm
+++ b/loader/bl_source/run_target_address.asm
@@ -1,0 +1,18 @@
+;-------------------------------------------------------------------------------
+; run_target_address.asm
+;
+; Heimir Thor Sverrisson, w1ant, heimir.sverrisson@gmail.com
+;
+; Define an integer at start of SRAM to store the run target
+;
+;-------------------------------------------------------------------------------
+; export reference
+    .def run_target
+
+; Target to run after reset
+;
+; 0x55555555 	Means enter Flashloader monitor
+; 0xAAAAAAAA	Means enter Application (if loaded)
+; other values	Unknown
+;
+run_target  .usect ".runTarget", 4

--- a/loader/bl_source/sci_common.c
+++ b/loader/bl_source/sci_common.c
@@ -182,7 +182,7 @@ void UART_send32BitData(sciBASE_t *sci, uint32_t data) {
  * @param  s: The string to be printed
  * @retval None
  */
-void UART_putString(sciBASE_t *sci, char *s) {
+void UART_putString(sciBASE_t *sci, const char *s) {
 	while (*s != '\0') {
 		UART_putChar(sci, *s);
 		s++;


### PR DESCRIPTION
Adding a run target variable in RAM that controls boot behaviour. See the `README` for further details., the table below
shows how the the combination of the value on the GPIO pin and the target pattern combined control the run target.
Note that `0x00000000` is a placeholder for any unknown pattern. 

| GPIO	| Target pattern | Jump to |
| ------|----------------|---------|
| Low	  | 0x55555555 | Loader |
| Low	  | 0xaaaaaaaa | Application |
| Low	  | 0x00000000 | Application |
| High  | 0x55555555 | Loader |
| High  | 0xaaaaaaaa | Application |
| High  | 0x00000000 | Loader |

Two new menu items have also been added to the flash loader. 

7. Select Run target
8. Soft reset

These are actions to control the new run target functionality