### PR TITLE
Watchdog support

### DIFF
--- a/.cproject
+++ b/.cproject
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?fileVersion 4.0.0?><cproject storage_type_id="org.eclipse.cdt.core.XmlProjectDescriptionStorage">
-	<storageModule moduleId="org.eclipse.cdt.core.settings">
+	<storageModule configRelations="2" moduleId="org.eclipse.cdt.core.settings">
 		<cconfiguration id="com.ti.ccstudio.buildDefinitions.TMS470.Debug.932358991">
 			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.ti.ccstudio.buildDefinitions.TMS470.Debug.932358991" moduleId="org.eclipse.cdt.core.settings" name="Debug">
 				<externalSettings/>

--- a/README.md
+++ b/README.md
@@ -300,7 +300,8 @@ directly to the application code.
 
 In addition, the RT-IHU includes a **watchdog**.  The code running in the RT-IHU must toggle the **watchdog reset**
 pin (aka kick the watchdog) at least every few milliseconds or the processor will reset.  The pin for the
-watchdog reset is SPI1 (when set up as a GIO) pin 1.  The watchdog chip has ignores resets that are too often.
-The flash loader has the capability of skipping resets based on the processor's RTI counter.  However that
+watchdog reset is SPI1 (when set up as a GIO) pin 1.  The watchdog chip has ignores resets that are too often so it
+might be that in some cases, the loader would kick the watchdog too quickly.  Thus
+the flash loader has the capability of skipping resets based on the processor's RTI counter.  However that
 adds code and uses additional chip capabilities, so it can be turned off by not defining **WATCHDOG_TIMED_WAIT**
-in bl_config.h
+in bl_config.h.

--- a/README.md
+++ b/README.md
@@ -289,3 +289,18 @@ assumes that HET tool has been installed and its `\bin` directory added to `PATH
 
 For a detailed description of exception handling between the Flashloader and the
 loaded application see the [Exception Handling document](docs/ExceptionHandling.md)
+
+## Use in AMSAT RT-IHU
+
+There are two details required by the AMSAT RT-IHU satellite on-board computer.  One is mentioned above
+and called the **prompt pin**.  On Golf, this is called the **Attached** line, which is high when there
+is an umbilical attached. When the umbilical is attached, this loader will be started and will be ready
+to load new code.  In space there will never be an umbilical attached, and thus this loader will jump
+directly to the application code.
+
+In addition, the RT-IHU includes a **watchdog**.  The code running in the RT-IHU must toggle the **watchdog reset**
+pin (aka kick the watchdog) at least every few milliseconds or the processor will reset.  The pin for the
+watchdog reset is SPI1 (when set up as a GIO) pin 1.  The watchdog chip has ignores resets that are too often.
+The flash loader has the capability of skipping resets based on the processor's RTI counter.  However that
+adds code and uses additional chip capabilities, so it can be turned off by not defining **WATCHDOG_TIMED_WAIT**
+in bl_config.h

--- a/loader/bl_include/bl_config.h
+++ b/loader/bl_include/bl_config.h
@@ -48,7 +48,8 @@
 // Port and pin to use for watchdog
 #define WATCHDOG_PORT spiPORT1
 #define WATCHDOG_PIN 1
-#define MIN_WATCHDOG_TOGGLE 20 /*How many clock ticks must we wait between toggles*/
+#define WATCHDOG_TIMED_WAIT /*Undefine this turn off clock waits for hitting watchdog*/
+#define MIN_WATCHDOG_TOGGLE 1000 /*How many clock ticks must we wait between toggles*/
 
 
 //*****************************************************************************

--- a/loader/bl_include/bl_config.h
+++ b/loader/bl_include/bl_config.h
@@ -48,7 +48,7 @@
 // Port and pin to use for watchdog
 #define WATCHDOG_PORT spiPORT1
 #define WATCHDOG_PIN 1
-#define WATCHDOG_TIMED_WAIT /*Undefine this turn off clock waits for hitting watchdog*/
+//#define WATCHDOG_TIMED_WAIT /*Undefine this turn off clock waits for hitting watchdog*/
 #define MIN_WATCHDOG_TOGGLE 1000 /*How many clock ticks must we wait between toggles*/
 
 

--- a/loader/bl_include/bl_config.h
+++ b/loader/bl_include/bl_config.h
@@ -45,6 +45,12 @@
 
 #define N2HET_INPUT_PIN 8
 
+// Port and pin to use for watchdog
+#define WATCHDOG_PORT spiPORT1
+#define WATCHDOG_PIN 1
+#define MIN_WATCHDOG_TOGGLE 20 /*How many clock ticks must we wait between toggles*/
+
+
 //*****************************************************************************
 // The starting address of the application.  This must be a multiple of 32K(sector size)
 // bytes (making it aligned to a page boundary), and can not be 0 (the first sector is 

--- a/loader/bl_include/bl_watchdog.h
+++ b/loader/bl_include/bl_watchdog.h
@@ -1,0 +1,16 @@
+/*
+ * bl_watchdog.h
+ *
+ *  Created on: Apr 10, 2023
+ *      Author: bfisher
+ */
+
+#ifndef LOADER_BL_INCLUDE_BL_WATCHDOG_H_
+#define LOADER_BL_INCLUDE_BL_WATCHDOG_H_
+
+void kickWatchdog(void);
+void startCounter(void);
+
+
+
+#endif /* LOADER_BL_INCLUDE_BL_WATCHDOG_H_ */

--- a/loader/bl_source/bl_main.c
+++ b/loader/bl_source/bl_main.c
@@ -13,7 +13,7 @@
 #include "sci.h"
 #include "bl_input_queue.h"
 #include "het.h"
-
+#include "bl_watchdog.h"
 /*****************************************************************************
  *
  * This holds the current remaining size in bytes to be downloaded.

--- a/loader/bl_source/bl_main.c
+++ b/loader/bl_source/bl_main.c
@@ -66,6 +66,7 @@ uint8_t *g_pucDataBuffer;
 static uint8 c;
 
 void loader_main(void) {
+    startCounter();
 #ifndef USE_N2HET
 	sciInit();
 	sciSetBaudrate(UART, UART_BAUDRATE);

--- a/loader/bl_source/bl_watchdog.c
+++ b/loader/bl_source/bl_watchdog.c
@@ -1,0 +1,165 @@
+/*
+ * bl_watchdog.c
+ *
+ *  Created on: Apr 10, 2023
+ *      Author: bfisher
+ */
+
+#include "reg_spi.h"
+#include "reg_rti.h"
+#include "gio.h"
+#include "bl_config.h"
+
+void kickWatchdog(void){
+    uint32_t currentValue,currentCounter;;
+    uint32_t pinMask = (1<<WATCHDOG_PIN);
+    static uint32_t lastCounterValue=0;
+    int32_t diffCounter;
+    currentCounter = rtiREG1->CNT[0].FRCx;
+    diffCounter = (int32_t)currentCounter - (int32_t)lastCounterValue;
+    if(diffCounter > MIN_WATCHDOG_TOGGLE){
+        lastCounterValue = currentCounter;
+        WATCHDOG_PORT->DIR |= pinMask; //Set the watchdog pin to allow input
+        currentValue = WATCHDOG_PORT->DIN;
+        currentValue = ~currentValue & pinMask; //currentValue has now has the value of the pin we want, and 0 in the rest
+        if (currentValue == 0){
+            WATCHDOG_PORT->DSET = pinMask; //Invert the pin to kick the wd.
+        } else {
+            WATCHDOG_PORT->DCLR = pinMask;
+        }
+    } else if (diffCounter<0){
+        lastCounterValue = currentCounter;
+    } //Here, it wrapped.
+}
+void rtiInit(void)
+{
+/* USER CODE BEGIN (3) */
+/* USER CODE END */
+    /** @b Initialize @b RTI1: */
+
+    /** - Setup NTU source, debug options and disable both counter blocks */
+    rtiREG1->GCTRL = (uint32)((uint32)0x0U << 16U) | 0x00000000U;
+
+    /** - Setup timebase for free running counter 0 */
+    rtiREG1->TBCTRL = 0x00000000U;
+
+    /** - Enable/Disable capture event sources for both counter blocks */
+    rtiREG1->CAPCTRL = 0U | 0U;
+
+    /** - Setup input source compare 0-3 */
+    rtiREG1->COMPCTRL = 0x00001000U | 0x00000100U | 0x00000000U | 0x00000000U;
+
+    /** - Reset up counter 0 */
+    rtiREG1->CNT[0U].UCx = 0x00000000U;
+
+    /** - Reset free running counter 0 */
+    rtiREG1->CNT[0U].FRCx = 0x00000000U;
+
+    /** - Setup up counter 0 compare value
+    *     - 0x00000000: Divide by 2^32
+    *     - 0x00000001-0xFFFFFFFF: Divide by (CPUC0 + 1)
+    */
+    rtiREG1->CNT[0U].CPUCx = 7U;
+
+    /** - Reset up counter 1 */
+    rtiREG1->CNT[1U].UCx = 0x00000000U;
+
+    /** - Reset free running counter 1 */
+    rtiREG1->CNT[1U].FRCx  = 0x00000000U;
+
+    /** - Setup up counter 1 compare value
+    *     - 0x00000000: Divide by 2^32
+    *     - 0x00000001-0xFFFFFFFF: Divide by (CPUC1 + 1)
+    */
+    rtiREG1->CNT[1U].CPUCx = 7U;
+
+    /** - Setup compare 0 value. This value is compared with selected free running counter. */
+    rtiREG1->CMP[0U].COMPx = 100000U;
+
+    /** - Setup update compare 0 value. This value is added to the compare 0 value on each compare match. */
+    rtiREG1->CMP[0U].UDCPx = 100000U;
+
+    /** - Setup compare 1 value. This value is compared with selected free running counter. */
+    rtiREG1->CMP[1U].COMPx = 570000U;
+
+    /** - Setup update compare 1 value. This value is added to the compare 1 value on each compare match. */
+    rtiREG1->CMP[1U].UDCPx = 570000U;
+
+    /** - Setup compare 2 value. This value is compared with selected free running counter. */
+    rtiREG1->CMP[2U].COMPx = 80000U;
+
+    /** - Setup update compare 2 value. This value is added to the compare 2 value on each compare match. */
+    rtiREG1->CMP[2U].UDCPx = 80000U;
+
+    /** - Setup compare 3 value. This value is compared with selected free running counter. */
+    rtiREG1->CMP[3U].COMPx = 100000U;
+
+    /** - Setup update compare 3 value. This value is added to the compare 3 value on each compare match. */
+    rtiREG1->CMP[3U].UDCPx = 100000U;
+
+    /** - Clear all pending interrupts */
+    rtiREG1->INTFLAG = 0x0007000FU;
+
+    /** - Disable all interrupts */
+    rtiREG1->CLEARINTENA = 0x00070F0FU;
+
+    /**   @note This function has to be called before the driver can be used.\n
+    *           This function has to be executed in privileged mode.\n
+    *           This function does not start the counters.
+    */
+
+/* USER CODE BEGIN (4) */
+/* USER CODE END */
+}
+
+/* USER CODE BEGIN (5) */
+/* USER CODE END */
+
+
+/** @fn void rtiStartCounter(uint32 counter)
+*   @brief Starts RTI Counter block
+*   @param[in] counter Select counter block to be started:
+*              - rtiCOUNTER_BLOCK0: RTI counter block 0 will be started
+*              - rtiCOUNTER_BLOCK1: RTI counter block 1 will be started
+*
+*   This function starts selected counter block of the selected RTI module.
+*/
+
+/* USER CODE BEGIN (6) */
+/* USER CODE END */
+/* SourceId : RTI_SourceId_002 */
+/* DesignId : RTI_DesignId_002 */
+/* Requirements : HL_SR77 */
+void rtiStartCounter(uint32 counter)
+{
+/* USER CODE BEGIN (7) */
+/* USER CODE END */
+
+    rtiREG1->GCTRL |= ((uint32)1U << (counter & 3U));
+
+    /**   @note The function rtiInit has to be called before this function can be used.\n
+    *           This function has to be executed in privileged mode.
+    */
+
+/* USER CODE BEGIN (8) */
+/* USER CODE END */
+}
+
+/* USER CODE BEGIN (9) */
+/* USER CODE END */
+
+
+/** @fn void rtiStopCounter(uint32 counter)
+*   @brief Stops RTI Counter block
+*   @param[in] counter Select counter to be stopped:
+*              - rtiCOUNTER_BLOCK0: RTI counter block 0 will be stopped
+*              - rtiCOUNTER_BLOCK1: RTI counter block 1 will be stopped
+*
+*   This function stops selected counter block of the selected RTI module.
+*/
+void startCounter(void){
+    rtiInit();
+    rtiStartCounter(0);
+
+}
+

--- a/loader/bl_source/sci_common.c
+++ b/loader/bl_source/sci_common.c
@@ -28,6 +28,7 @@
 #include "string.h"
 #include "bl_input_queue.h"
 #include "het.h"
+#include "bl_watchdog.h"
 
 #if defined (UART_ENABLE_UPDATE)
 
@@ -126,7 +127,9 @@ uint32_t Str2Int(unsigned char *inputstr, int *intnum) {
  * block until one is ready
  */
 char UART_getKey(sciBASE_t *sci) {
-	while(getQueueSize() == 0)
+	while(getQueueSize() == 0){
+	    kickWatchdog();
+	}
 		;
 	return dequeue();
 }
@@ -137,6 +140,7 @@ char UART_getKey(sciBASE_t *sci) {
  */
 int UART_getChar(sciBASE_t *sci, uint32_t timeout) {
 	while(timeout-- > 0){
+	    kickWatchdog();
 		if(getQueueSize() > 0)
 			return dequeue();
 	}
@@ -200,6 +204,7 @@ void UART_putChar(sciBASE_t *sci, char c) {
 		;
 	sci->TD = c;
 #else
+	kickWatchdog();
 	HetUART1PutChar(c);
 #endif
 }
@@ -210,6 +215,7 @@ void UART_putChar(sciBASE_t *sci, char c) {
  * @retval 0: Byte sent
  */
 uint32_t UART_txByte(sciBASE_t *sci, char c) {
+    kickWatchdog();
 #ifndef USE_N2HET
 	while ((sci->FLR & (uint32)SCI_TX_INT) == 0)
 		;

--- a/targetConfigs/TMS570LS0914.ccxml
+++ b/targetConfigs/TMS570LS0914.ccxml
@@ -48,6 +48,11 @@
             
             
             
+            <property Type="choicelist" Value="1" id="Debug Probe Selection">
+                <choice Name="Select by serial number" value="0">
+                    <property Type="stringfield" Value="L3122222" id="-- Enter the serial number"/>
+                </choice>
+            </property>
             <platform XML_version="1.2" id="platform_0">
                                                                                                                 
                 

--- a/targetConfigs/TMS570LS0914.ccxml
+++ b/targetConfigs/TMS570LS0914.ccxml
@@ -50,7 +50,7 @@
             
             <property Type="choicelist" Value="1" id="Debug Probe Selection">
                 <choice Name="Select by serial number" value="0">
-                    <property Type="stringfield" Value="L3122222" id="-- Enter the serial number"/>
+                    <property Type="stringfield" Value="L2381111" id="-- Enter the serial number"/>
                 </choice>
             </property>
             <platform XML_version="1.2" id="platform_0">


### PR DESCRIPTION
I've added watchdog support to the flash loader.  The watchdog pin matches the pin required for the Golf RT-IHU.  I also include code (which is ifdef'ed out) that can use the TMS570 RTI counter to ensure the wd does not get reset too often (and thus look like noise).  However, that does not appear to be required, so I've turned it off to avoid the extra code.