### PR TITLE
Allow use of 'v' and 'a' for 'version' and 'start application'

### DIFF
--- a/loader/bl_source/bl_uart.c
+++ b/loader/bl_source/bl_uart.c
@@ -166,10 +166,10 @@ void UpdaterUART(void) {
 		} else if (key == 0x32) {
 			/* Upload user application from the Flash */
 			UART_Upload();
-		} else if (key == 0x33) {
+		} else if ((key == 0x33) || (key == 'a')) {
 			JumpAddress = (uint32_t) APP_START_ADDRESS;
 			((void (*)(void)) JumpAddress)();
-		} else if (key == 0x34) {
+		} else if ((key == 0x34) || (key == 'v')) {
 			get_software_Version();
 		} else if (key == 0x35) {
 			get_hardware_Info();


### PR DESCRIPTION
This is to match the LIHU flash loader so that people who use it only occasionally only have to memorize one way to start the app or to figure out if they are in the flash loader (or use the memorized info they already have)